### PR TITLE
Fix/private endpoints

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -70,7 +70,7 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-            #
+
       # - name: Assign Storage Account Contributor Role to SP
       #   run: |
       #     az role assignment create \

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -122,7 +122,7 @@ jobs:
           # vid utskapande av vm, peka lösenord på secret id.
           TF_VAR_admin_username: ${{ secrets.TF_VAR_admin_username }}
           TF_VAR_admin_password: ${{ secrets.TF_VAR_admin_password }}
-        run: terraform plan -input=false -out=plan.out  -var-file='dev.tfvars'
+        run: terraform plan -input=false -var "runner_public_ip=${{ steps.discover_ip.outputs.public_ip }}" -out=plan.out  -var-file='dev.tfvars'
             #-var "runner_public_ip=${{ steps.discover_ip.outputs.public_ip }}"
       - name: Terraform Apply
         env:
@@ -130,7 +130,7 @@ jobs:
           # vid utskapande av vm, peka lösenord på secret id.
           TF_VAR_admin_username: ${{ secrets.TF_VAR_admin_username }} # for key vault 
           TF_VAR_admin_password: ${{ secrets.TF_VAR_admin_password }} # for key vault
-        run: terraform apply -auto-approve -input=false -var-file='dev.tfvars'
+        run: terraform apply -auto-approve -input=false -var "runner_public_ip=${{ steps.discover_ip.outputs.public_ip }}" -var-file='dev.tfvars'
             #-var "runner_public_ip=${{ steps.discover_ip.outputs.public_ip }}"
         
 

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -71,7 +71,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
           # necessary? remove if can solve storage account access
-      - name: Assign Role to Service Principal
+      - name: Assign Storage Blob Data Contributor to Service Principal
         run: |
           az role assignment create \
             --assignee ${{ secrets.AZURE_CLIENT_ID }} \
@@ -79,7 +79,13 @@ jobs:
             --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
         continue-on-error: false
 
-
+      - name: Assign Storage Account Contributor Role to SP
+        run: |
+          az role assignment create \
+            --assignee ${{ secrets.AZURE_CLIENT_ID }} \
+            --role "Storage Account Contributor" \
+            --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}/resourceGroups/rg_project1/providers/Microsoft.Storage/storageAccounts/examplestoraccount5421
+        continue-on-error: false
 
       - name: Export Azure env vars for Terraform
         run: |

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -123,7 +123,7 @@ jobs:
           TF_VAR_admin_username: ${{ secrets.TF_VAR_admin_username }}
           TF_VAR_admin_password: ${{ secrets.TF_VAR_admin_password }}
         run: terraform plan -input=false -var "runner_public_ip=${{ steps.discover_ip.outputs.public_ip }}" -out=plan.out  -var-file='dev.tfvars'
-            #-var "runner_public_ip=${{ steps.discover_ip.outputs.public_ip }}"
+
       - name: Terraform Apply
         env:
           # inte bra. impelmentera terraform som använder keyvaults och secrets med random module.
@@ -131,7 +131,6 @@ jobs:
           TF_VAR_admin_username: ${{ secrets.TF_VAR_admin_username }} # for key vault 
           TF_VAR_admin_password: ${{ secrets.TF_VAR_admin_password }} # for key vault
         run: terraform apply -auto-approve -input=false -var "runner_public_ip=${{ steps.discover_ip.outputs.public_ip }}" -var-file='dev.tfvars'
-            #-var "runner_public_ip=${{ steps.discover_ip.outputs.public_ip }}"
         
 
 

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -71,22 +71,22 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
             
-      - name: Assign Storage Account Contributor Role to SP
-        run: |
-          az role assignment create \
-            --assignee ${{ secrets.AZURE_CLIENT_ID }} \
-            --role "Storage Account Contributor" \
-            --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        continue-on-error: false
+      # - name: Assign Storage Account Contributor Role to SP
+      #   run: |
+      #     az role assignment create \
+      #       --assignee ${{ secrets.AZURE_CLIENT_ID }} \
+      #       --role "Storage Account Contributor" \
+      #       --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      #   continue-on-error: false
 
            
-      - name: Assign Storage Blob Data Contributor to Service Principal
-        run: |
-          az role assignment create \
-            --assignee ${{ secrets.AZURE_CLIENT_ID }} \
-            --role "Storage Blob Data Contributor" \
-            --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        continue-on-error: false
+      # - name: Assign Storage Blob Data Contributor to Service Principal
+      #   run: |
+      #     az role assignment create \
+      #       --assignee ${{ secrets.AZURE_CLIENT_ID }} \
+      #       --role "Storage Blob Data Contributor" \
+      #       --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      #   continue-on-error: false
 
 
         

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -88,7 +88,7 @@ jobs:
       #       --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
       #   continue-on-error: false
 
-#
+
         
       # - name: Wait for Role Assignment Propagation
       #   run: sleep 30

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -55,7 +55,7 @@ jobs:
   #   steps:
   #     - name: Output issue event data
   #       run: echo '${{ toJSON(github.event) }}'
-
+#
   cicd:
     runs-on: ubuntu-latest
     environment: azure-deployment

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -84,7 +84,7 @@ jobs:
           az role assignment create \
             --assignee ${{ secrets.AZURE_CLIENT_ID }} \
             --role "Storage Account Contributor" \
-            --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}/resourceGroups/rg_project1/providers/Microsoft.Storage/storageAccounts/examplestoraccount5421
+            --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
         continue-on-error: false
 
       - name: Export Azure env vars for Terraform

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -31,9 +31,9 @@ name: terraform ci/cd
 
 on:
   push:
-    branches: [main, 'fix-**', 'feature/**']
+    branches: [main, 'fix/**', 'feature/**']
   pull_request:
-    branches: [main, 'fix-**', 'feature/**']
+    branches: [main, 'fix/**', 'feature/**']
 
   workflow_dispatch:
 

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -70,6 +70,7 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+          # necessary? remove if can solve storage account access
       - name: Assign Role to Service Principal
         run: |
           az role assignment create \

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -78,12 +78,12 @@ jobs:
           echo "ARM_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}" >> $GITHUB_ENV
           echo "ARM_USE_OIDC=true" >> $GITHUB_ENV
 
-      - name: Discover runner's IP
-        id: discover_ip
-        run: echo "public_ip=$(curl -s ifconfig.me)" >> $GITHUB_OUTPUT
+      # - name: Discover runner's IP
+      #   id: discover_ip
+      #   run: echo "public_ip=$(curl -s ifconfig.me)" >> $GITHUB_OUTPUT
           
-      - name: Print IP (for debugging)
-        run: echo "My IP is ${{ steps.discover_ip.outputs.public_ip }}"
+      # - name: Print IP (for debugging)
+      #   run: echo "My IP is ${{ steps.discover_ip.outputs.public_ip }}"
         
 
 
@@ -112,15 +112,16 @@ jobs:
           # vid utskapande av vm, peka lösenord på secret id.
           TF_VAR_admin_username: ${{ secrets.TF_VAR_admin_username }}
           TF_VAR_admin_password: ${{ secrets.TF_VAR_admin_password }}
-        run: terraform plan -input=false -out=plan.out -var "runner_public_ip=${{ steps.discover_ip.outputs.public_ip }}" -var-file='dev.tfvars'
-
+        run: terraform plan -input=false -out=plan.out  -var-file='dev.tfvars'
+            #-var "runner_public_ip=${{ steps.discover_ip.outputs.public_ip }}"
       - name: Terraform Apply
         env:
           # inte bra. impelmentera terraform som använder keyvaults och secrets med random module.
           # vid utskapande av vm, peka lösenord på secret id.
           TF_VAR_admin_username: ${{ secrets.TF_VAR_admin_username }} # for key vault 
           TF_VAR_admin_password: ${{ secrets.TF_VAR_admin_password }} # for key vault
-        run: terraform apply -auto-approve -input=false -var "runner_public_ip=${{ steps.discover_ip.outputs.public_ip }}" -var-file='dev.tfvars'
+        run: terraform apply -auto-approve -input=false -var-file='dev.tfvars'
+            #-var "runner_public_ip=${{ steps.discover_ip.outputs.public_ip }}"
         
 
 

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -90,8 +90,8 @@ jobs:
 
 
         
-      - name: Wait for Role Assignment Propagation
-        run: sleep 30
+      # - name: Wait for Role Assignment Propagation
+      #   run: sleep 30
 
 
       - name: Export Azure env vars for Terraform

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -70,7 +70,7 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-            
+            #
       # - name: Assign Storage Account Contributor Role to SP
       #   run: |
       #     az role assignment create \

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -86,6 +86,11 @@ jobs:
             --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
         continue-on-error: false
 
+        
+      - name: Wait for Role Assignment Propagation
+        run: sleep 30
+
+
       - name: Export Azure env vars for Terraform
         run: |
           echo "ARM_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}" >> $GITHUB_ENV

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -55,7 +55,6 @@ jobs:
   #   steps:
   #     - name: Output issue event data
   #       run: echo '${{ toJSON(github.event) }}'
-#
   cicd:
     runs-on: ubuntu-latest
     environment: azure-deployment

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -71,22 +71,22 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
 
-      - name: Assign Storage Account Contributor Role to SP
-        run: |
-          az role assignment create \
-            --assignee ${{ secrets.AZURE_CLIENT_ID }} \
-            --role "Storage Account Contributor" \
-            --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        continue-on-error: false
+      # - name: Assign Storage Account Contributor Role to SP
+      #   run: |
+      #     az role assignment create \
+      #       --assignee ${{ secrets.AZURE_CLIENT_ID }} \
+      #       --role "Storage Account Contributor" \
+      #       --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      #   continue-on-error: false
 
            
-      - name: Assign Storage Blob Data Contributor to Service Principal
-        run: |
-          az role assignment create \
-            --assignee ${{ secrets.AZURE_CLIENT_ID }} \
-            --role "Storage Blob Data Contributor" \
-            --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        continue-on-error: false
+      # - name: Assign Storage Blob Data Contributor to Service Principal
+      #   run: |
+      #     az role assignment create \
+      #       --assignee ${{ secrets.AZURE_CLIENT_ID }} \
+      #       --role "Storage Blob Data Contributor" \
+      #       --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      #   continue-on-error: false
 
 
       # - name: Wait for Role Assignment Propagation

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
+#
       - name: Azure Login
         uses: Azure/login@v2.2.0
         with:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -71,25 +71,24 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
 
-      # - name: Assign Storage Account Contributor Role to SP
-      #   run: |
-      #     az role assignment create \
-      #       --assignee ${{ secrets.AZURE_CLIENT_ID }} \
-      #       --role "Storage Account Contributor" \
-      #       --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      #   continue-on-error: false
+      - name: Assign Storage Account Contributor Role to SP
+        run: |
+          az role assignment create \
+            --assignee ${{ secrets.AZURE_CLIENT_ID }} \
+            --role "Storage Account Contributor" \
+            --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        continue-on-error: false
 
            
-      # - name: Assign Storage Blob Data Contributor to Service Principal
-      #   run: |
-      #     az role assignment create \
-      #       --assignee ${{ secrets.AZURE_CLIENT_ID }} \
-      #       --role "Storage Blob Data Contributor" \
-      #       --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      #   continue-on-error: false
+      - name: Assign Storage Blob Data Contributor to Service Principal
+        run: |
+          az role assignment create \
+            --assignee ${{ secrets.AZURE_CLIENT_ID }} \
+            --role "Storage Blob Data Contributor" \
+            --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        continue-on-error: false
 
 
-        
       # - name: Wait for Role Assignment Propagation
       #   run: sleep 30
 

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -70,6 +70,16 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+            
+      - name: Assign Storage Account Contributor Role to SP
+        run: |
+          az role assignment create \
+            --assignee ${{ secrets.AZURE_CLIENT_ID }} \
+            --role "Storage Account Contributor" \
+            --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        continue-on-error: false
+
+           
       - name: Assign Storage Blob Data Contributor to Service Principal
         run: |
           az role assignment create \
@@ -78,13 +88,6 @@ jobs:
             --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
         continue-on-error: false
 
-      - name: Assign Storage Account Contributor Role to SP
-        run: |
-          az role assignment create \
-            --assignee ${{ secrets.AZURE_CLIENT_ID }} \
-            --role "Storage Account Contributor" \
-            --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        continue-on-error: false
 
         
       - name: Wait for Role Assignment Propagation

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -106,7 +106,7 @@ jobs:
           
       - name: Print IP (for debugging)
         run: echo "My IP is ${{ steps.discover_ip.outputs.public_ip }}"
-        
+       # 
 
 
       - name: Setup Terraform

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -70,7 +70,6 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-          # necessary? remove if can solve storage account access
       - name: Assign Storage Blob Data Contributor to Service Principal
         run: |
           az role assignment create \

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -71,6 +71,16 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Assign Role to Service Principal
+        run: |
+          az role assignment create \
+            --assignee ${{ secrets.AZURE_CLIENT_ID }} \
+            --role "User Access Administrator" \
+            --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        continue-on-error: false # Fail if role assignment fails         
+
+
+
       - name: Export Azure env vars for Terraform
         run: |
           echo "ARM_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }}" >> $GITHUB_ENV

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -75,7 +75,7 @@ jobs:
         run: |
           az role assignment create \
             --assignee ${{ secrets.AZURE_CLIENT_ID }} \
-            --role "User Access Administrator" \
+            --role "Storage Blob Data Contributor" \
             --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
         continue-on-error: false
 

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -76,7 +76,7 @@ jobs:
             --assignee ${{ secrets.AZURE_CLIENT_ID }} \
             --role "User Access Administrator" \
             --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        continue-on-error: false # Fail if role assignment fails         
+        continue-on-error: false
 
 
 

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -88,12 +88,12 @@ jobs:
           echo "ARM_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}" >> $GITHUB_ENV
           echo "ARM_USE_OIDC=true" >> $GITHUB_ENV
 
-      # - name: Discover runner's IP
-      #   id: discover_ip
-      #   run: echo "public_ip=$(curl -s ifconfig.me)" >> $GITHUB_OUTPUT
+      - name: Discover runner's IP
+        id: discover_ip
+        run: echo "public_ip=$(curl -s ifconfig.me)" >> $GITHUB_OUTPUT
           
-      # - name: Print IP (for debugging)
-      #   run: echo "My IP is ${{ steps.discover_ip.outputs.public_ip }}"
+      - name: Print IP (for debugging)
+        run: echo "My IP is ${{ steps.discover_ip.outputs.public_ip }}"
         
 
 

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -88,7 +88,7 @@ jobs:
       #       --scope /subscriptions/${{ secrets.AZURE_SUBSCRIPTION_ID }}
       #   continue-on-error: false
 
-
+#
         
       # - name: Wait for Role Assignment Propagation
       #   run: sleep 30

--- a/dev.tfvars
+++ b/dev.tfvars
@@ -1,3 +1,7 @@
+terraform_sp_object_id = "43ae005a-35b4-43de-8b12-8adcea9811c4"
+
+
+
 resource_group_name = "rg_project1"
 location            = "North Europe"
 
@@ -67,7 +71,6 @@ log_categories = [
   "AzureFirewallNetworkRule",
   "AzureFirewallDnsProxy"
 ]
-
 
 
 # log_analytics_saved_search = {

--- a/dev.tfvars
+++ b/dev.tfvars
@@ -72,11 +72,3 @@ log_categories = [
   "AzureFirewallDnsProxy"
 ]
 
-
-# log_analytics_saved_search = {
-#   search1 = {
-#     category = "AzureFirewallNetworkRule"
-#     display_name = "Sample Network Rule Logs"
-#     query = "search *"
-#   }
-# }

--- a/dev.tfvars
+++ b/dev.tfvars
@@ -67,8 +67,8 @@ vnet_route_table = {
 
 
 log_categories = [
-  "AzureFirewallApplicationRule",
-  "AzureFirewallNetworkRule",
-  "AzureFirewallDnsProxy"
+  "azurefirewallapplicationrule",
+  "azurefirewallnetworkrule",
+  "azurefirewalldnsproxy"
 ]
 

--- a/main.tf
+++ b/main.tf
@@ -96,6 +96,7 @@ module "storage_account" {
   location            = var.location
   subnet_ids          = module.networking.subnet_ids
   vnet_ids            = module.networking.vnet_ids
+  terraform_sp_object_id = var.terraform_sp_object_id
   #runner_public_ip    = var.runner_public_ip
 }
 

--- a/main.tf
+++ b/main.tf
@@ -97,6 +97,6 @@ module "storage_account" {
   subnet_ids          = module.networking.subnet_ids
   vnet_ids            = module.networking.vnet_ids
   terraform_sp_object_id = var.terraform_sp_object_id
-  #runner_public_ip    = var.runner_public_ip
+  runner_public_ip    = var.runner_public_ip
 }
 

--- a/main.tf
+++ b/main.tf
@@ -71,8 +71,8 @@ module "compute" {
 
   storage_account_name = module.storage_account.storage_account_name
   container_name       = module.storage_account.container_name
-  blob_name = module.storage_account.blob_name
-  custom_data_sas_url = module.storage_account.scripts_sas_url
+  blob_name            = module.storage_account.blob_name
+  custom_data_sas_url  = module.storage_account.scripts_sas_url
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -96,6 +96,6 @@ module "storage_account" {
   location            = var.location
   subnet_ids          = module.networking.subnet_ids
   vnet_ids            = module.networking.vnet_ids
-  runner_public_ip    = var.runner_public_ip
+  #runner_public_ip    = var.runner_public_ip
 }
 

--- a/modules/azure_compute/main.tf
+++ b/modules/azure_compute/main.tf
@@ -1,18 +1,3 @@
-
-
-//to be disabled because using the firewall ip?
-/* resource "azurerm_public_ip" "my_pip" {
-  for_each            = var.vnets
-  name                = "pip-${each.key}"
-  resource_group_name = var.resource_group_name
-  location            = var.location
-  allocation_method   = "Static"
-} */
-
-
-#give the vm's? storage blob data contributor?
-
-
 resource "azurerm_network_interface" "my_nics" {
   for_each            = var.vnets
   name                = each.value.nic_name
@@ -23,7 +8,6 @@ resource "azurerm_network_interface" "my_nics" {
     name                          = "internal"
     subnet_id                     = var.subnet_ids[each.key]
     private_ip_address_allocation = "Dynamic"
-    #public_ip_address_id          = azurerm_public_ip.my_pip[each.key].id # remove because afw is external ip? how to add another nic then?
   }
 }
 
@@ -39,14 +23,11 @@ resource "azurerm_linux_virtual_machine" "my_vms" {
   custom_data = base64encode(<<EOT
 #!/bin/bash
 # Download the script from blob storage with SAS token
-curl -f -o /tmp/script.sh "${var.custom_data_sas_url}"
-chmod +x /tmp/script.sh
-/tmp/script.sh
-EOT
+  curl -f -o /tmp/script.sh "${var.custom_data_sas_url}"
+  chmod +x /tmp/script.sh
+  /tmp/script.sh
+  EOT
   )
-
-
-
 
   admin_username = var.admin_username //theadmintothevm
   admin_password = var.admin_password //Redeploy2025!!

--- a/modules/azure_monitoring/main.tf
+++ b/modules/azure_monitoring/main.tf
@@ -14,11 +14,11 @@ resource "azurerm_log_analytics_workspace" "firewall_logs" {
 
 
 resource "azurerm_monitor_diagnostic_setting" "firewall_diagnostics" {
-  name                       = "$var.firewall_id-diagnostic-settings"
+  name                       = "${var.firewall_id}-diagnostics"
   target_resource_id         = var.firewall_id
   log_analytics_workspace_id = azurerm_log_analytics_workspace.firewall_logs.id
 
-  # Dynamically enable logs
+/*   # Dynamically enable logs
   dynamic "enabled_log" {
     for_each = var.log_categories
 
@@ -26,13 +26,29 @@ resource "azurerm_monitor_diagnostic_setting" "firewall_diagnostics" {
       category = enabled_log.value
     }
   }
-
-  # Metrics
+ */
   metric {
+    category = "azurefirewallapplicationrule"
+    enabled = true
+  }
+
+
+  metric {
+    category = "azurefirewallnetworkrule"
+    enabled = true
+  }
+
+
+  metric {
+    category = "azurefirewalldnsproxy"
+    enabled = true
+  }
+
+/*   metric {
     category = "AllMetrics"
     enabled  = true
   }
-
+ */
   depends_on = [
     azurerm_log_analytics_workspace.firewall_logs,
     var.firewall_id

--- a/modules/azure_monitoring/main.tf
+++ b/modules/azure_monitoring/main.tf
@@ -11,20 +11,10 @@ resource "azurerm_log_analytics_workspace" "firewall_logs" {
 
 
 
-# │ Error: A resource with the ID "/subscriptions/***/resourceGroups/rg_project1/providers/Microsoft.Network/azureFirewalls/firewall|firewall-diagnostic-setting" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_monitor_diagnostic_setting" for more information.
-# │ 
-# │   with module.monitoring.azurerm_monitor_diagnostic_setting.firewall_diagnostics,
-# │   on modules/azure_monitoring/main.tf line 16, in resource "azurerm_monitor_diagnostic_setting" "firewall_diagnostics":
-# │   16: resource "azurerm_monitor_diagnostic_setting" "firewall_diagnostics" {
-# │ 
-# ╵
-# https://chatgpt.com/c/6784deb7-28d0-800b-b2ce-b173ce333f30
-
-
 
 
 resource "azurerm_monitor_diagnostic_setting" "firewall_diagnostics" {
-  name                       = "firewall-diagnostic-setting"
+  name                       = "$var.firewall_id-diagnostic-settings"
   target_resource_id         = var.firewall_id
   log_analytics_workspace_id = azurerm_log_analytics_workspace.firewall_logs.id
 
@@ -68,6 +58,16 @@ AzureDiagnostics
 EOT
 }
 
+
+
+# │ Error: A resource with the ID "/subscriptions/***/resourceGroups/rg_project1/providers/Microsoft.Network/azureFirewalls/firewall|firewall-diagnostic-setting" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_monitor_diagnostic_setting" for more information.
+# │ 
+# │   with module.monitoring.azurerm_monitor_diagnostic_setting.firewall_diagnostics,
+# │   on modules/azure_monitoring/main.tf line 16, in resource "azurerm_monitor_diagnostic_setting" "firewall_diagnostics":
+# │   16: resource "azurerm_monitor_diagnostic_setting" "firewall_diagnostics" {
+# │ 
+# ╵
+# https://chatgpt.com/c/6784deb7-28d0-800b-b2ce-b173ce333f30
 
 
 

--- a/modules/azure_monitoring/main.tf
+++ b/modules/azure_monitoring/main.tf
@@ -14,41 +14,30 @@ resource "azurerm_log_analytics_workspace" "firewall_logs" {
 
 
 resource "azurerm_monitor_diagnostic_setting" "firewall_diagnostics" {
-  name                       = "${var.firewall_id}-diagnostics"
+  name                       = "diagnostics-settings"
   target_resource_id         = var.firewall_id
   log_analytics_workspace_id = azurerm_log_analytics_workspace.firewall_logs.id
 
-/*   # Dynamically enable logs
-  dynamic "enabled_log" {
-    for_each = var.log_categories
 
-    content {
-      category = enabled_log.value
-    }
-  }
- */
-  metric {
+  // Enable logs for specific categories
+  enabled_log {
     category = "azurefirewallapplicationrule"
-    enabled = true
   }
 
-
-  metric {
+  enabled_log {
     category = "azurefirewallnetworkrule"
-    enabled = true
   }
 
-
-  metric {
+  enabled_log {
     category = "azurefirewalldnsproxy"
+  }
+
+  // Enable metrics
+  metric {
+    category = "AllMetrics"
     enabled = true
   }
 
-/*   metric {
-    category = "AllMetrics"
-    enabled  = true
-  }
- */
   depends_on = [
     azurerm_log_analytics_workspace.firewall_logs,
     var.firewall_id

--- a/modules/azure_network/main.tf
+++ b/modules/azure_network/main.tf
@@ -150,7 +150,7 @@ resource "azurerm_firewall_network_rule_collection" "inter_vm_traffic" {
   }
 }
 
-## Allows compute to resolve domain names via Azure DNS
+## Allows compute to resolve domain names via Azure DNS (important for resolving the *storage-account*.privatelink... url)
 resource "azurerm_firewall_network_rule_collection" "dns_allow" {
   name                = "allow_dns"
   azure_firewall_name = azurerm_firewall.firewall.name

--- a/modules/azure_network/main.tf
+++ b/modules/azure_network/main.tf
@@ -14,7 +14,25 @@ resource "azurerm_virtual_network" "my_vnet" {
 # │ Virtual Network Name: "vnet1"): performing Delete: unexpected status 400 (400 Bad Request) with error: InUseSubnetCannotBeDeleted: Subnet subnet1 is in use by /subscriptions/3e00befb-2b03-4b60-b8a0-faf06ad28b5e/resourceGroups/RG_PROJECT1/providers/Microsoft.Network/networkInterfaces/NIC1/ipConfigurations/INTERNAL and cannot be deleted. In order to delete the subnet, delete all the resources within the subnet. See aka.ms/deletesubnet.
 
 
+
+
 resource "azurerm_subnet" "my_subnet" {
+  for_each = var.vnets
+
+  resource_group_name  = var.resource_group_name
+  name                 = each.value.subnet_name
+  virtual_network_name = azurerm_virtual_network.my_vnet[each.key].name
+  address_prefixes     = each.value.subnet_prefix
+
+  # Enable Microsoft.Storage service endpoint
+  service_endpoints = ["Microsoft.Storage"]
+
+  depends_on = [azurerm_virtual_network.my_vnet]
+}
+
+
+# Before added service endpoints to allow private access to storage acocunt
+/* resource "azurerm_subnet" "my_subnet" {
   for_each = var.vnets
 
   resource_group_name  = var.resource_group_name
@@ -23,7 +41,8 @@ resource "azurerm_subnet" "my_subnet" {
   address_prefixes     = each.value.subnet_prefix
 
   depends_on = [azurerm_virtual_network.my_vnet]
-}
+} */
+
 
 #---------------------------------
 

--- a/modules/azure_network/main.tf
+++ b/modules/azure_network/main.tf
@@ -24,7 +24,6 @@ resource "azurerm_subnet" "my_subnet" {
   virtual_network_name = azurerm_virtual_network.my_vnet[each.key].name
   address_prefixes     = each.value.subnet_prefix
 
-  # Enable Microsoft.Storage service endpoint
   service_endpoints = ["Microsoft.Storage"]
 
   depends_on = [azurerm_virtual_network.my_vnet]

--- a/modules/azure_network/main.tf
+++ b/modules/azure_network/main.tf
@@ -31,12 +31,12 @@ resource "azurerm_subnet" "my_subnet" {
 resource "azurerm_virtual_network" "firewall_vnet" {
   resource_group_name = var.resource_group_name
   location            = var.location
-  name          = var.afw.firewall_vnet_name
-  address_space = var.afw.firewall_vnet_prefix
+  name                = var.afw.firewall_vnet_name
+  address_space       = var.afw.firewall_vnet_prefix
 }
 
 resource "azurerm_subnet" "firewall_subnet" {
-  resource_group_name = var.resource_group_name
+  resource_group_name  = var.resource_group_name
   name                 = var.afw.firewall_subnet_name
   virtual_network_name = var.afw.firewall_vnet_name
   address_prefixes     = var.afw.firewall_subnet_prefix
@@ -155,7 +155,7 @@ resource "azurerm_firewall_network_rule_collection" "dns_allow" {
   name                = "allow_dns"
   azure_firewall_name = azurerm_firewall.firewall.name
   resource_group_name = var.resource_group_name
-  priority            = 200 
+  priority            = 200
   action              = "Allow"
 
   rule {
@@ -179,7 +179,7 @@ resource "azurerm_firewall_network_rule_collection" "allow_azure_storage" {
   rule {
     name                  = "allow-blob-storage-vnet1"
     source_addresses      = ["10.0.0.0/16"] # Only include the subnet range for vnet1
-    destination_addresses = ["Storage"]  
+    destination_addresses = ["Storage"]
     destination_ports     = ["443"]
     protocols             = ["TCP"]
   }
@@ -188,7 +188,7 @@ resource "azurerm_firewall_network_rule_collection" "allow_azure_storage" {
   rule {
     name                  = "allow-blob-storage-vnet2"
     source_addresses      = ["10.1.0.0/16"] # Only include the subnet range for vnet2
-    destination_addresses = ["Storage"] 
+    destination_addresses = ["Storage"]
     destination_ports     = ["443"]
     protocols             = ["TCP"]
   }

--- a/modules/azure_network/main.tf
+++ b/modules/azure_network/main.tf
@@ -226,7 +226,6 @@ resource "azurerm_firewall_nat_rule_collection" "nginx_inbound_dnat" {
   }
 }
 
-
 ## Allows secure outbound internet access for VMs in vnet1 and vnet2
 resource "azurerm_firewall_network_rule_collection" "outbound_internet" {
   name                = "allow_outbound_internet"
@@ -243,11 +242,3 @@ resource "azurerm_firewall_network_rule_collection" "outbound_internet" {
     protocols             = ["TCP"]
   }
 }
-
-
-#
-
-
-//also create outbound nginx rule to servers?
-
-

--- a/modules/azure_network/outputs.tf
+++ b/modules/azure_network/outputs.tf
@@ -28,10 +28,7 @@ output "firewall_id" {
   value       = azurerm_firewall.firewall.id
 }
 
-# output "firewall_ip_backuo" {
-#   description = "Public IP of firewall"
-#   value       = azurerm_firewall.firewall.ip_configuration[0].public_ip_address_id
-# }
+
 
 output "firewall_ip" {
   value = azurerm_public_ip.firewall_ip.ip_address

--- a/modules/azure_network/outputs.tf
+++ b/modules/azure_network/outputs.tf
@@ -32,7 +32,7 @@ output "firewall_id" {
 
 output "firewall_ip" {
   value = azurerm_public_ip.firewall_ip.ip_address
-  
+
 }
 
 # output "firewall_private_ip" {

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -17,6 +17,7 @@ locals {
   )
 }
 
+//break these out in their own module
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_role_assignment" "storage_account_contributor" {

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -68,7 +68,7 @@ resource "azurerm_storage_account_network_rules" "storage_rules" {
 
 
   virtual_network_subnet_ids = values(var.subnet_ids) //allow vnets to access blob to download script
-  ip_rules = [var.runner_public_ip] //whitelist IP of github runner to allow hosting script
+  ip_rules = [var.runner_public_ip] //attempt to whitelist IP of github runner to allow hosting script. however ip of public runners are ephemeral so changes. makes unable to upload blob using SP with default action "Deny"
 }
 
 

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -64,7 +64,9 @@ resource "azurerm_storage_account_network_rules" "storage_rules" {
 
 # I think the reason this happens is that Github actions uses multiple runners. The first runner (which gets the IP) is not the same that then tries to upload the script to the blob?
 # One way to solve this would be to do private runners and allow ip and subnet of it.
-
+# to filter ip addresses for github actions:
+# curl -s https://api.github.com/meta \
+#  | jq '.actions[] | select(contains(":") | not)'
 
 
   virtual_network_subnet_ids = values(var.subnet_ids) //allow vnets to access blob to download script

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -80,6 +80,8 @@ resource "azurerm_storage_blob" "script_blob" {
   storage_container_name = azurerm_storage_container.script_container.name
   type                   = "Block"
   source                 = "${path.module}/custom_data/docker.sh"
+  depends_on             = [azurerm_storage_container.script_container]
+
 }
 
 
@@ -106,8 +108,8 @@ data "azurerm_storage_account_sas" "scripts_sas" {
 
   permissions {
     read    = true 
-    create  = true # can be disabled?
     write   = true # can be disabled?
+    create  = false # can be disabled?
     list    = false
     delete  = false
     add     = false

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -101,20 +101,19 @@ resource "azurerm_storage_account" "blob_storage_account" {
 resource "azurerm_storage_account_network_rules" "storage_rules" {
   storage_account_id = azurerm_storage_account.blob_storage_account.id
 
-  default_action = "Deny"  # Blocks everything except explicitly allowed traffic
-  bypass         = ["AzureServices"]
+  default_action = "Deny"
+  bypass = ["AzureServices"]
 
-  virtual_network_subnet_ids = values(module.network.subnet_ids) # Converts map to list
+  virtual_network_subnet_ids = values(var.subnet_ids) 
 }
 
-# 🔹 Assign Private Link Access for Each Subnet 🔹
 resource "azurerm_storage_account_network_rules" "private_link_access" {
-  for_each = module.network.subnet_ids
+  for_each = var.subnet_ids 
 
   storage_account_id = azurerm_storage_account.blob_storage_account.id
 
-  default_action = "Deny"  # Ensures unlisted traffic is blocked
-  bypass         = ["AzureServices"]
+  default_action = "Deny"
+  bypass = ["AzureServices"]
 
   private_link_access {
     endpoint_resource_id = each.value

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -161,8 +161,8 @@ data "azurerm_storage_account_sas" "scripts_sas" {
 
   permissions {
     read    = true
-    create  = false
-    write   = false
+    create  = true
+    write   = true
     list    = false
     delete  = false
     add     = false

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -54,7 +54,7 @@ resource "azurerm_storage_account_network_rules" "storage_rules" {
   storage_account_id = azurerm_storage_account.blob_storage_account.id
 
   default_action = "Allow" #Allow/Deny... I want this to be Deny because otherwise there's no use in my "private endpoints configs"... However, when i put Deny I get the following error:
-
+  
 #   │ Error: retrieving properties for Blob "script.sh" (Account "Account \"examplestoraccount5421\" (IsEdgeZone false / ZoneName \"\" / Subdomain Type \"blob\" / DomainSuffix \"core.windows.net\")" / Container Name "scripts"): executing request: unexpected status 403 (403 This request is not authorized to perform this operation.) with EOF
 # │ 
 # │   with module.storage_account.azurerm_storage_blob.script_blob,

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -45,9 +45,15 @@ resource "azurerm_storage_account" "blob_storage_account" {
   }
 
   network_rules {
-    default_action = "Allow"
-    #ip_rules = [var.runner_public_ip] //remnant from trying to allow SP to deploy script to script container. however for this to work i need a self-hosted runner in a vnet...
+    default_action = "Allow" #or do deny?
     bypass = ["AzureServices"]
+    # private_link_access {
+    #   endpoint_resource_id = [
+    #     var.subnet_ids["vnet1"],
+    #     var.subnet_ids["vnet2"],
+    #   ]
+    # }
+    #ip_rules = [var.runner_public_ip] //remnant from trying to allow SP to deploy script to script container. however for this to work i need a self-hosted runner in a vnet...
   }
 
   share_properties {

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -17,6 +17,20 @@ locals {
   )
 }
 
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_role_assignment" "storage_account_contributor" {
+  principal_id   = service_principal_object_id
+  role_definition_name = "Storage Account Contributor"
+  scope          = azurerm_storage_account.blob_storage_account.id
+}
+
+resource "azurerm_role_assignment" "storage_blob_data_contributor" {
+  principal_id   = service_principal_object_id
+  role_definition_name = "Storage Blob Data Contributor"
+  scope          = azurerm_storage_account.blob_storage_account.id
+}
+
 
 resource "azurerm_storage_account" "blob_storage_account" {
   name                            = "examplestoraccount5421"
@@ -27,7 +41,7 @@ resource "azurerm_storage_account" "blob_storage_account" {
   account_kind                    = "StorageV2"
   access_tier                     = "Cool"
   public_network_access_enabled   = true // enabled because i need SP to deploy script. otherwise would need self-hosted SP runner and enable network connection from it to storage account.
-  default_to_oauth_authentication = false
+  default_to_oauth_authentication = true
   allow_nested_items_to_be_public = false
   https_traffic_only_enabled      = true
   large_file_share_enabled        = true //false?
@@ -109,7 +123,7 @@ data "azurerm_storage_account_sas" "scripts_sas" {
   permissions {
     read    = true 
     write   = true # can be disabled?
-    create  = false # can be disabled?
+    create  = true # can be disabled?
     list    = false
     delete  = false
     add     = false

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -62,23 +62,6 @@ resource "azurerm_storage_account_network_rules" "storage_rules" {
 
 
 
-###################
-# version 2...? fix
-# resource "azurerm_storage_account_network_rules" "this" {
-#   storage_account_id = azurerm_storage_account.blob_storage_account.id
-#   default_action     = "Deny"
-#   bypass            = ["AzureServices"]
-
-#   virtual_network_subnet_ids = values(var.subnet_ids)
-
-#   dynamic "private_link_access" {
-#     for_each = var.subnet_ids
-#     content {
-#       endpoint_resource_id = ...
-#     }
-#   }
-# }
-
 
 
 resource "azurerm_storage_container" "script_container" {

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -25,7 +25,7 @@ resource "azurerm_storage_account" "blob_storage_account" {
   account_replication_type        = "LRS"
   account_kind                    = "StorageV2"
   access_tier                     = "Cool"
-  public_network_access_enabled   = false // enabled because i need SP to deploy script. otherwise would need self-hosted SP runner and enable network connection from it to storage account.
+  public_network_access_enabled   = true // enabled because i need SP to deploy script. otherwise would need self-hosted SP runner and enable network connection from it to storage account.
   default_to_oauth_authentication = true
 
   allow_nested_items_to_be_public = false
@@ -45,14 +45,14 @@ resource "azurerm_storage_account" "blob_storage_account" {
   }
 
   network_rules {
-    default_action = "Allow" #or do deny?
+    default_action = "Deny" #or do deny?
     bypass = ["AzureServices"]
-    # private_link_access {
-    #   endpoint_resource_id = [
-    #     var.subnet_ids["vnet1"],
-    #     var.subnet_ids["vnet2"],
-    #   ]
-    # }
+    private_link_access {
+      endpoint_resource_id = [
+        var.subnet_ids["vnet1"],
+        var.subnet_ids["vnet2"],
+      ]
+    }
     #ip_rules = [var.runner_public_ip] //remnant from trying to allow SP to deploy script to script container. however for this to work i need a self-hosted runner in a vnet...
   }
 

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -18,22 +18,22 @@ locals {
 }
 #------------------------------------------------
 
-resource "azurerm_role_assignment" "storage_blob_data_contributor" {
-  principal_id        = var.terraform_sp_object_id # Directly use SP's Object ID
-  role_definition_name = "Storage Blob Data Contributor"
-  scope               = azurerm_storage_account.blob_storage_account.id
-}
+# resource "azurerm_role_assignment" "storage_blob_data_contributor" {
+#   principal_id        = var.terraform_sp_object_id # Directly use SP's Object ID
+#   role_definition_name = "Storage Blob Data Contributor"
+#   scope               = azurerm_storage_account.blob_storage_account.id
+# }
 
 
 
 
 
-resource "null_resource" "delay" {
-  depends_on = [azurerm_role_assignment.storage_blob_data_contributor]
-  provisioner "local-exec" {
-    command = "sleep 15" # Wait for 15 seconds
-  }
-}
+# resource "null_resource" "delay" {
+#   depends_on = [azurerm_role_assignment.storage_blob_data_contributor]
+#   provisioner "local-exec" {
+#     command = "sleep 15" # Wait for 15 seconds
+#   }
+# }
 
 #------------------------------------------------
 resource "azurerm_storage_account" "blob_storage_account" {

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -52,8 +52,14 @@ resource "azurerm_storage_account" "blob_storage_account" {
 resource "azurerm_storage_account_network_rules" "storage_rules" {
   storage_account_id = azurerm_storage_account.blob_storage_account.id
 
-  default_action = "Allow" # deny?
-  bypass         = ["AzureServices"]
+  default_action = "Allow" # I want this to be Deny because otherwise there's no use in my "private endpoints configs"... However, when i put Deny I get the following error:
+
+#   │ Error: retrieving properties for Blob "script.sh" (Account "Account \"examplestoraccount5421\" (IsEdgeZone false / ZoneName \"\" / Subdomain Type \"blob\" / DomainSuffix \"core.windows.net\")" / Container Name "scripts"): executing request: unexpected status 403 (403 This request is not authorized to perform this operation.) with EOF
+# │ 
+# │   with module.storage_account.azurerm_storage_blob.script_blob,
+# │   on modules/azure_storage_account/main.tf line 74, in resource "azurerm_storage_blob" "script_blob":
+# │   74: resource "azurerm_storage_blob" "script_blob" {
+#   bypass         = ["AzureServices"]
 
   virtual_network_subnet_ids = values(var.subnet_ids) //allow vnets to access blob to download script
   ip_rules = [var.runner_public_ip] //whitelist IP of github runner to allow hosting script

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -53,7 +53,7 @@ resource "azurerm_storage_account" "blob_storage_account" {
 resource "azurerm_storage_account_network_rules" "storage_rules" {
   storage_account_id = azurerm_storage_account.blob_storage_account.id
 
-  default_action = "Deny" #Allow/Deny... I want this to be Deny because otherwise there's no use in my "private endpoints configs"... However, when i put Deny I get the following error:
+  default_action = "Allow" #Allow/Deny... I want this to be Deny because otherwise there's no use in my "private endpoints configs"... However, when i put Deny I get the following error:
 
 #   │ Error: retrieving properties for Blob "script.sh" (Account "Account \"examplestoraccount5421\" (IsEdgeZone false / ZoneName \"\" / Subdomain Type \"blob\" / DomainSuffix \"core.windows.net\")" / Container Name "scripts"): executing request: unexpected status 403 (403 This request is not authorized to perform this operation.) with EOF
 # │ 
@@ -61,6 +61,11 @@ resource "azurerm_storage_account_network_rules" "storage_rules" {
 # │   on modules/azure_storage_account/main.tf line 74, in resource "azurerm_storage_blob" "script_blob":
 # │   74: resource "azurerm_storage_blob" "script_blob" {
 #   bypass         = ["AzureServices"]
+
+# I think the reason this happens is that Github actions uses multiple runners. The first runner (which gets the IP) is not the same that then tries to upload the script to the blob?
+# One way to solve this would be to do private runners and allow ip and subnet of it.
+
+
 
   virtual_network_subnet_ids = values(var.subnet_ids) //allow vnets to access blob to download script
   ip_rules = [var.runner_public_ip] //whitelist IP of github runner to allow hosting script

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -125,6 +125,8 @@ resource "azurerm_storage_account_network_rules" "this" {
 
   # Combine all subnet IDs into one list
   virtual_network_subnet_ids = values(var.subnet_ids)
+  ip_rules = [var.runner_public_ip]
+  #   #ip_rules = [var.runner_public_ip] //remnant from trying to allow SP to deploy script to script container. however for this to work i need a self-hosted runner in a vnet...
 }
 
 

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -162,6 +162,11 @@ resource "azurerm_storage_blob" "script_blob" {
   storage_container_name = azurerm_storage_container.script_container.name
   type                   = "Block"
   source                 = "${path.module}/custom_data/docker.sh"
+  #is below necessary?
+  depends_on = [
+    azurerm_storage_container.script_container,
+    azurerm_storage_account_network_rules.storage_rules
+  ]
   #depends_on = [azurerm_storage_container.script_container]
 }
 
@@ -190,8 +195,8 @@ data "azurerm_storage_account_sas" "scripts_sas" {
 
   permissions {
     read    = true
-    create  = false
-    write   = false
+    create  = true
+    write   = true
     list    = false
     delete  = false
     add     = false

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -100,8 +100,8 @@ data "azurerm_storage_account_sas" "scripts_sas" {
 
   permissions {
     read    = true
-    create  = true
-    write   = true
+    create  = false
+    write   = false
     list    = false
     delete  = false
     add     = false

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -72,7 +72,7 @@ resource "azurerm_storage_blob" "script_blob" {
   type                   = "Block"
   source                 = "${path.module}/custom_data/docker.sh" 
 
-  depends_on = [azurerm_storage_container.script_container]
+  #depends_on = [azurerm_storage_container.script_container]
 }
 
 
@@ -147,7 +147,7 @@ resource "azurerm_private_endpoint" "blob_private_endpoint" {
     private_connection_resource_id = azurerm_storage_account.blob_storage_account.id
     subresource_names              = ["blob"]
   }
-  depends_on = [azurerm_storage_account.blob_storage_account] //can be removed because of implicit dep. from private_connection_...
+  #depends_on = [azurerm_storage_account.blob_storage_account] //can be removed because of implicit dep. from private_connection_...
 }
 
 
@@ -168,59 +168,3 @@ resource "azurerm_private_dns_a_record" "storage_blob_a_record" {
 }
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-/* 
-
-resource "azurerm_private_endpoint" "example1" {
-  name                = "vnet1_access"
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  subnet_id           = "/subscriptions/3e00befb-2b03-4b60-b8a0-faf06ad28b5e/resourceGroups/rg_project1/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/subnet1"
-
-  private_service_connection {
-    name                              = "vnet1_access_connection"
-    is_manual_connection = false
-    private_connection_resource_id    = azurerm_storage_account.example.id
-    subresource_names                 = ["blob"]
-  }
-}
-
-
-resource "azurerm_private_endpoint" "example2" {
-  name                = "vnet2_access"
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  subnet_id           = "/subscriptions/3e00befb-2b03-4b60-b8a0-faf06ad28b5e/resourceGroups/rg_project1/providers/Microsoft.Network/virtualNetworks/vnet2/subnets/subnet2"
-
-  private_service_connection {
-    name                              = "vnet2_access_connection"
-    is_manual_connection = false
-    private_connection_resource_id    = azurerm_storage_account.example.id
-    subresource_names                 = ["blob"]
-  }
-}
-
- */

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -163,10 +163,6 @@ resource "azurerm_storage_blob" "script_blob" {
   type                   = "Block"
   source                 = "${path.module}/custom_data/docker.sh"
   #is below necessary?
-  depends_on = [
-    azurerm_storage_container.script_container,
-    azurerm_storage_account_network_rules.storage_rules
-  ]
   #depends_on = [azurerm_storage_container.script_container]
 }
 
@@ -175,7 +171,6 @@ resource "azurerm_storage_blob" "script_blob" {
 data "azurerm_storage_account_sas" "scripts_sas" {
   connection_string = azurerm_storage_account.blob_storage_account.primary_connection_string
   https_only        = true
-  #signed_version    = "2022-11-02"
 
   resource_types {
     service   = true

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -113,7 +113,7 @@ resource "azurerm_storage_account_network_rules" "private_link_access" {
 resource "azurerm_storage_account_network_rules" "storage_rules" {
   storage_account_id = azurerm_storage_account.blob_storage_account.id
 
-  default_action = "Allow" # deny?
+  default_action = "Deny" # deny?
   bypass         = ["AzureServices"]
 
   # Combine all subnet IDs into one list

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -44,7 +44,7 @@ resource "azurerm_storage_account" "blob_storage_account" {
   account_replication_type        = "LRS"
   account_kind                    = "StorageV2"
   access_tier                     = "Cool"
-  public_network_access_enabled   = true // enabled because i need SP to deploy script. otherwise would need self-hosted SP runner and enable network connection from it to storage account.
+  public_network_access_enabled   = false // enabled because i need SP to deploy script. otherwise would need self-hosted SP runner and enable network connection from it to storage account.
   default_to_oauth_authentication = true
   allow_nested_items_to_be_public = false
   https_traffic_only_enabled      = true
@@ -101,10 +101,9 @@ resource "azurerm_storage_account" "blob_storage_account" {
 resource "azurerm_storage_account_network_rules" "storage_rules" {
   storage_account_id = azurerm_storage_account.blob_storage_account.id
 
-  default_action = "Deny"  # Security best practice: Block everything except explicitly allowed traffic
+  default_action = "Deny" # when i allow, it works. but this is bad practice. 
   bypass         = ["AzureServices"]
 
-  # 🔹 Allow access from all subnets where Terraform SP is deployed
   virtual_network_subnet_ids = values(var.subnet_ids)
 }
 

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -98,7 +98,7 @@ resource "azurerm_storage_account" "blob_storage_account" {
   # }
 }
 
-resource "azurerm_storage_account_network_rules" "storage_rules" {
+/* resource "azurerm_storage_account_network_rules" "storage_rules" {
   storage_account_id = azurerm_storage_account.blob_storage_account.id
 
   default_action = "Deny" # when i allow, it works. but this is bad practice. 
@@ -114,8 +114,22 @@ resource "azurerm_storage_account_network_rules" "private_link_access" {
 
   default_action = "Deny"
   bypass = ["AzureServices"]
+} */
 
+
+resource "azurerm_storage_account_network_rules" "this" {
+  storage_account_id = azurerm_storage_account.blob_storage_account.id
+
+  default_action = "Deny"  # Deny all traffic by default
+  bypass         = ["AzureServices"]  # Allow essential Azure services like monitoring
+
+  # Combine all subnet IDs into one list
+  virtual_network_subnet_ids = values(var.subnet_ids)
 }
+
+
+
+
 ###################
 # version 2...? fix
 # resource "azurerm_storage_account_network_rules" "this" {
@@ -230,15 +244,10 @@ resource "azurerm_private_endpoint" "blob_private_endpoint" {
       azurerm_private_dns_zone.blob_dns_zone.id
     ]
   }
-
-
-
-  #depends_on = [azurerm_storage_account.blob_storage_account] //can be removed because of implicit dep. from private_connection_...
 }
 
 
-
-resource "azurerm_private_dns_a_record" "storage_blob_a_record" {
+/* resource "azurerm_private_dns_a_record" "storage_blob_a_record" {
   # We also do for_each on var.subnet_ids to match the multiple endpoints above.
   for_each = var.subnet_ids
 
@@ -251,6 +260,14 @@ resource "azurerm_private_dns_a_record" "storage_blob_a_record" {
     # Link each A-record to the correct private endpoint’s IP address
     azurerm_private_endpoint.blob_private_endpoint[each.key].private_service_connection[0].private_ip_address
   ]
-}
+} */
+
+# commented out because of having it here isntead:
+  # private_dns_zone_group {
+  #   name = "default"
+  #   private_dns_zone_ids = [
+  #     azurerm_private_dns_zone.blob_dns_zone.id
+
+
 
 

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -42,7 +42,7 @@ resource "azurerm_storage_account_network_rules" "storage_rules" {
   bypass         = ["AzureServices"]
 
   virtual_network_subnet_ids = values(var.subnet_ids) //allow vnets to access blob to download script
-  ip_rules = [var.runner_public_ip] //whitelist IP of runner to allow hosting script
+  ip_rules = [var.runner_public_ip] //whitelist IP of github runner to allow hosting script
 }
 
 

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -20,13 +20,13 @@ locals {
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_role_assignment" "storage_account_contributor" {
-  principal_id   = service_principal_object_id
+  principal_id   = data.azurerm_client_config.current.object_id
   role_definition_name = "Storage Account Contributor"
   scope          = azurerm_storage_account.blob_storage_account.id
 }
 
 resource "azurerm_role_assignment" "storage_blob_data_contributor" {
-  principal_id   = service_principal_object_id
+  principal_id   = data.azurerm_client_config.current.object_id
   role_definition_name = "Storage Blob Data Contributor"
   scope          = azurerm_storage_account.blob_storage_account.id
 }

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -38,7 +38,7 @@ resource "azurerm_storage_account" "blob_storage_account" {
 resource "azurerm_storage_account_network_rules" "storage_rules" {
   storage_account_id = azurerm_storage_account.blob_storage_account.id
 
-  default_action = "Deny" # deny?
+  default_action = "Allow" # deny?
   bypass         = ["AzureServices"]
 
   virtual_network_subnet_ids = values(var.subnet_ids) //allow vnets to access blob to download script

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -117,7 +117,7 @@ resource "azurerm_storage_account_network_rules" "private_link_access" {
 } */
 
 
-resource "azurerm_storage_account_network_rules" "this" {
+resource "azurerm_storage_account_network_rules" "storage_rules" {
   storage_account_id = azurerm_storage_account.blob_storage_account.id
 
   default_action = "Deny"  # Deny all traffic by default
@@ -164,8 +164,6 @@ resource "azurerm_storage_blob" "script_blob" {
   storage_container_name = azurerm_storage_container.script_container.name
   type                   = "Block"
   source                 = "${path.module}/custom_data/docker.sh"
-  #is below necessary?
-  #depends_on = [azurerm_storage_container.script_container]
 }
 
 

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -118,20 +118,20 @@ resource "azurerm_storage_account_network_rules" "private_link_access" {
 }
 ###################
 # version 2...? fix
-resource "azurerm_storage_account_network_rules" "this" {
-  storage_account_id = azurerm_storage_account.blob_storage_account.id
-  default_action     = "Deny"
-  bypass            = ["AzureServices"]
+# resource "azurerm_storage_account_network_rules" "this" {
+#   storage_account_id = azurerm_storage_account.blob_storage_account.id
+#   default_action     = "Deny"
+#   bypass            = ["AzureServices"]
 
-  virtual_network_subnet_ids = values(var.subnet_ids)
+#   virtual_network_subnet_ids = values(var.subnet_ids)
 
-  dynamic "private_link_access" {
-    for_each = var.subnet_ids
-    content {
-      endpoint_resource_id = ...
-    }
-  }
-}
+#   dynamic "private_link_access" {
+#     for_each = var.subnet_ids
+#     content {
+#       endpoint_resource_id = ...
+#     }
+#   }
+# }
 
 
 
@@ -176,8 +176,8 @@ data "azurerm_storage_account_sas" "scripts_sas" {
 
   permissions {
     read    = true
-    create  = true
-    write   = true
+    create  = false
+    write   = false
     list    = false
     delete  = false
     add     = false
@@ -223,6 +223,16 @@ resource "azurerm_private_endpoint" "blob_private_endpoint" {
     private_connection_resource_id = azurerm_storage_account.blob_storage_account.id
     subresource_names              = ["blob"]
   }
+
+  private_dns_zone_group {
+    name = "default"
+    private_dns_zone_ids = [
+      azurerm_private_dns_zone.blob_dns_zone.id
+    ]
+  }
+
+
+
   #depends_on = [azurerm_storage_account.blob_storage_account] //can be removed because of implicit dep. from private_connection_...
 }
 

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -66,15 +66,8 @@ resource "azurerm_storage_account" "blob_storage_account" {
     default_action = "Deny"
     bypass = ["AzureServices"]
 
-    virtual_network_subnet_ids = [
-      for k, subnet_id in var.subnet_ids : subnet_id
-    ]
-
-    private_link_access {
-      endpoint_resource_id = [
-        for k, subnet_id in var.subnet_ids : subnet_id
-      ]
-    }
+]
+}
     }
    */
 
@@ -120,16 +113,13 @@ resource "azurerm_storage_account_network_rules" "private_link_access" {
 resource "azurerm_storage_account_network_rules" "storage_rules" {
   storage_account_id = azurerm_storage_account.blob_storage_account.id
 
-  default_action = "Allow"
+  default_action = "Allow" # deny?
   bypass         = ["AzureServices"]
 
   # Combine all subnet IDs into one list
   virtual_network_subnet_ids = values(var.subnet_ids)
   ip_rules = [var.runner_public_ip]
-  
-
-
-
+ 
   #   #ip_rules = [var.runner_public_ip] //remnant from trying to allow SP to deploy script to script container. however for this to work i need a self-hosted runner in a vnet...
 }
 
@@ -185,7 +175,7 @@ data "azurerm_storage_account_sas" "scripts_sas" {
   services {
     blob  = true
     queue = false
-    table = true
+    table = true #can be disabled?
     file  = false
   }
 
@@ -193,9 +183,9 @@ data "azurerm_storage_account_sas" "scripts_sas" {
   expiry = timeadd(timestamp(), "3h")
 
   permissions {
-    read    = true
-    create  = true
-    write   = true
+    read    = true 
+    create  = true # can be disabled?
+    write   = true # can be disabled?
     list    = false
     delete  = false
     add     = false

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -45,12 +45,11 @@ resource "azurerm_storage_account" "blob_storage_account" {
   }
 
   network_rules {
-    default_action = "Deny" #or do deny?
+    default_action = "Allow" # Preferred 'Deny' but SP doesn't have right RBAC to deploy script to storage
     bypass = ["AzureServices"]
-/*     private_link_access {
+  /*   private_link_access {
       endpoint_resource_id = [
-        var.subnet_ids["vnet1"],
-        var.subnet_ids["vnet2"],
+        for k, subnet_id in var.subnet_ids : subnet_id
       ]
     } */
     #ip_rules = [var.runner_public_ip] //remnant from trying to allow SP to deploy script to script container. however for this to work i need a self-hosted runner in a vnet...

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -17,6 +17,7 @@ locals {
   )
 }
 
+
 resource "azurerm_storage_account" "blob_storage_account" {
   name                            = "examplestoraccount5421"
   resource_group_name             = var.resource_group_name
@@ -30,7 +31,7 @@ resource "azurerm_storage_account" "blob_storage_account" {
 
   allow_nested_items_to_be_public = false
   https_traffic_only_enabled      = true
-  large_file_share_enabled        = true
+  large_file_share_enabled        = true //false?
   shared_access_key_enabled       = true
 
   blob_properties {

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -63,15 +63,32 @@ resource "azurerm_storage_account" "blob_storage_account" {
   }
 
   network_rules {
-    default_action = "Deny" # Preferred 'Deny' but SP doesn't have right RBAC to deploy script to storage
+    default_action = "Deny"
     bypass = ["AzureServices"]
-  /*   private_link_access {
+
+    virtual_network_subnet_ids = [
+      for k, subnet_id in var.subnet_ids : subnet_id
+    ]
+
+    private_link_access {
       endpoint_resource_id = [
         for k, subnet_id in var.subnet_ids : subnet_id
       ]
-    } */
-    #ip_rules = [var.runner_public_ip] //remnant from trying to allow SP to deploy script to script container. however for this to work i need a self-hosted runner in a vnet...
+    }
   }
+
+  
+  
+  # network_rules {
+  #   default_action = "Deny" # Preferred 'Deny' but SP doesn't have right RBAC to deploy script to storage
+  #   bypass = ["AzureServices"]
+  #   private_link_access {
+  #     endpoint_resource_id = [
+  #       for k, subnet_id in var.subnet_ids : subnet_id
+  #     ]
+  #   }
+  #   #ip_rules = [var.runner_public_ip] //remnant from trying to allow SP to deploy script to script container. however for this to work i need a self-hosted runner in a vnet...
+  # }
 
   share_properties {
     retention_policy {

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -116,9 +116,6 @@ resource "azurerm_storage_account_network_rules" "private_link_access" {
   default_action = "Deny"
   bypass = ["AzureServices"]
 
-  private_link_access {
-    endpoint_resource_id = each.value
-  }
 }
 
 

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -52,7 +52,7 @@ resource "azurerm_storage_account" "blob_storage_account" {
 resource "azurerm_storage_account_network_rules" "storage_rules" {
   storage_account_id = azurerm_storage_account.blob_storage_account.id
 
-  default_action = "Deny" # deny?
+  default_action = "Allow" # deny?
   bypass         = ["AzureServices"]
 
   virtual_network_subnet_ids = values(var.subnet_ids) //allow vnets to access blob to download script

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -101,10 +101,11 @@ resource "azurerm_storage_account" "blob_storage_account" {
 resource "azurerm_storage_account_network_rules" "storage_rules" {
   storage_account_id = azurerm_storage_account.blob_storage_account.id
 
-  default_action = "Deny"
-  bypass = ["AzureServices"]
+  default_action = "Deny"  # Security best practice: Block everything except explicitly allowed traffic
+  bypass         = ["AzureServices"]
 
-  virtual_network_subnet_ids = values(var.subnet_ids) 
+  # 🔹 Allow access from all subnets where Terraform SP is deployed
+  virtual_network_subnet_ids = values(var.subnet_ids)
 }
 
 resource "azurerm_storage_account_network_rules" "private_link_access" {

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -47,12 +47,12 @@ resource "azurerm_storage_account" "blob_storage_account" {
   network_rules {
     default_action = "Deny" #or do deny?
     bypass = ["AzureServices"]
-    private_link_access {
+/*     private_link_access {
       endpoint_resource_id = [
         var.subnet_ids["vnet1"],
         var.subnet_ids["vnet2"],
       ]
-    }
+    } */
     #ip_rules = [var.runner_public_ip] //remnant from trying to allow SP to deploy script to script container. however for this to work i need a self-hosted runner in a vnet...
   }
 

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -116,7 +116,22 @@ resource "azurerm_storage_account_network_rules" "private_link_access" {
   bypass = ["AzureServices"]
 
 }
+###################
+# version 2...? fix
+resource "azurerm_storage_account_network_rules" "this" {
+  storage_account_id = azurerm_storage_account.blob_storage_account.id
+  default_action     = "Deny"
+  bypass            = ["AzureServices"]
 
+  virtual_network_subnet_ids = values(var.subnet_ids)
+
+  dynamic "private_link_access" {
+    for_each = var.subnet_ids
+    content {
+      endpoint_resource_id = ...
+    }
+  }
+}
 
 
 

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -52,7 +52,7 @@ resource "azurerm_storage_account" "blob_storage_account" {
 resource "azurerm_storage_account_network_rules" "storage_rules" {
   storage_account_id = azurerm_storage_account.blob_storage_account.id
 
-  default_action = "Allow" # I want this to be Deny because otherwise there's no use in my "private endpoints configs"... However, when i put Deny I get the following error:
+  default_action = "Deny" #Allow/Deny... I want this to be Deny because otherwise there's no use in my "private endpoints configs"... However, when i put Deny I get the following error:
 
 #   │ Error: retrieving properties for Blob "script.sh" (Account "Account \"examplestoraccount5421\" (IsEdgeZone false / ZoneName \"\" / Subdomain Type \"blob\" / DomainSuffix \"core.windows.net\")" / Container Name "scripts"): executing request: unexpected status 403 (403 This request is not authorized to perform this operation.) with EOF
 # │ 

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -52,7 +52,7 @@ resource "azurerm_storage_account" "blob_storage_account" {
 resource "azurerm_storage_account_network_rules" "storage_rules" {
   storage_account_id = azurerm_storage_account.blob_storage_account.id
 
-  default_action = "Allow" # deny?
+  default_action = "Deny" # deny?
   bypass         = ["AzureServices"]
 
   virtual_network_subnet_ids = values(var.subnet_ids) //allow vnets to access blob to download script

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -27,7 +27,7 @@ resource "azurerm_storage_account" "blob_storage_account" {
   account_kind                    = "StorageV2"
   access_tier                     = "Cool"
   public_network_access_enabled   = true // enabled because i need SP to deploy script. otherwise would need self-hosted SP runner and enable network connection from it to storage account.
-  default_to_oauth_authentication = true
+  default_to_oauth_authentication = false
   allow_nested_items_to_be_public = false
   https_traffic_only_enabled      = true
   large_file_share_enabled        = true //false?

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -120,12 +120,16 @@ resource "azurerm_storage_account_network_rules" "private_link_access" {
 resource "azurerm_storage_account_network_rules" "storage_rules" {
   storage_account_id = azurerm_storage_account.blob_storage_account.id
 
-  default_action = "Deny"  # Deny all traffic by default
-  bypass         = ["AzureServices"]  # Allow essential Azure services like monitoring
+  default_action = "Allow"
+  bypass         = ["AzureServices"]
 
   # Combine all subnet IDs into one list
   virtual_network_subnet_ids = values(var.subnet_ids)
   ip_rules = [var.runner_public_ip]
+  
+
+
+
   #   #ip_rules = [var.runner_public_ip] //remnant from trying to allow SP to deploy script to script container. however for this to work i need a self-hosted runner in a vnet...
 }
 

--- a/modules/azure_storage_account/main.tf
+++ b/modules/azure_storage_account/main.tf
@@ -44,7 +44,7 @@ resource "azurerm_storage_account" "blob_storage_account" {
   account_replication_type        = "LRS"
   account_kind                    = "StorageV2"
   access_tier                     = "Cool"
-  public_network_access_enabled   = false // enabled because i need SP to deploy script. otherwise would need self-hosted SP runner and enable network connection from it to storage account.
+  public_network_access_enabled   = true // enabled because i need SP to deploy script. otherwise would need self-hosted SP runner and enable network connection from it to storage account.
   default_to_oauth_authentication = true
   allow_nested_items_to_be_public = false
   https_traffic_only_enabled      = true
@@ -152,7 +152,7 @@ data "azurerm_storage_account_sas" "scripts_sas" {
   services {
     blob  = true
     queue = false
-    table = false
+    table = true
     file  = false
   }
 

--- a/modules/azure_storage_account/outputs.tf
+++ b/modules/azure_storage_account/outputs.tf
@@ -21,13 +21,11 @@ output "scripts_sas_url" {
 # Note: difference between below? _main is in outputs main to see if script url works
 output "scripts_sas_token" {
   value = data.azurerm_storage_account_sas.scripts_sas.sas
-  sensitive = false
 }
 
 output "scripts_sas_url_main" {
   value       = local.scripts_sas_url
   description = "The SAS URL for the script blob, used for deployment"
-  sensitive   = false
 }
 
 

--- a/modules/azure_storage_account/outputs.tf
+++ b/modules/azure_storage_account/outputs.tf
@@ -10,12 +10,17 @@ output "blob_name" {
   value = azurerm_storage_blob.script_blob.name
 }
 
-output "scripts_sas_token" {
-  value = data.azurerm_storage_account_sas.scripts_sas.sas
-}
+
 
 output "scripts_sas_url" {
   value = local.scripts_sas_url
+}
+
+
+
+# Note: difference between below? _main is in outputs main to see if script url works
+output "scripts_sas_token" {
+  value = data.azurerm_storage_account_sas.scripts_sas.sas
 }
 
 output "scripts_sas_url_main" {

--- a/modules/azure_storage_account/outputs.tf
+++ b/modules/azure_storage_account/outputs.tf
@@ -18,6 +18,13 @@ output "scripts_sas_url" {
   value = local.scripts_sas_url
 }
 
+output "scripts_sas_url" {
+  value       = local.scripts_sas_url
+  description = "The SAS URL for the script blob, used for deployment"
+  #sensitive   = false
+}
+
+
 /* output "sas_token" {
   value = data.azurerm_storage_account_sas.blob_read_sas.sas
 }

--- a/modules/azure_storage_account/outputs.tf
+++ b/modules/azure_storage_account/outputs.tf
@@ -21,12 +21,13 @@ output "scripts_sas_url" {
 # Note: difference between below? _main is in outputs main to see if script url works
 output "scripts_sas_token" {
   value = data.azurerm_storage_account_sas.scripts_sas.sas
+  sensitive = false
 }
 
 output "scripts_sas_url_main" {
   value       = local.scripts_sas_url
   description = "The SAS URL for the script blob, used for deployment"
-  #sensitive   = false
+  sensitive   = false
 }
 
 

--- a/modules/azure_storage_account/outputs.tf
+++ b/modules/azure_storage_account/outputs.tf
@@ -18,7 +18,7 @@ output "scripts_sas_url" {
   value = local.scripts_sas_url
 }
 
-output "scripts_sas_url" {
+output "scripts_sas_url_main" {
   value       = local.scripts_sas_url
   description = "The SAS URL for the script blob, used for deployment"
   #sensitive   = false

--- a/modules/azure_storage_account/variables.tf
+++ b/modules/azure_storage_account/variables.tf
@@ -19,6 +19,12 @@ variable "vnet_ids" {
   type        = map(string)
 }
 
+variable "terraform_sp_object_id" {
+  description = "The Client ID of the Terraform Service Principal"
+}
+
+
+
 /* variable "runner_public_ip" {
   type        = string
   description = "Public IP of the GitHub Actions runner"

--- a/modules/azure_storage_account/variables.tf
+++ b/modules/azure_storage_account/variables.tf
@@ -23,8 +23,6 @@ variable "terraform_sp_object_id" {
   description = "The Client ID of the Terraform Service Principal"
 }
 
-
-
 variable "runner_public_ip" {
   type        = string
   description = "Public IP of the GitHub Actions runner"

--- a/modules/azure_storage_account/variables.tf
+++ b/modules/azure_storage_account/variables.tf
@@ -25,9 +25,7 @@ variable "terraform_sp_object_id" {
 
 
 
-/* variable "runner_public_ip" {
+variable "runner_public_ip" {
   type        = string
   description = "Public IP of the GitHub Actions runner"
 }
-
- */

--- a/modules/azure_storage_account/variables.tf
+++ b/modules/azure_storage_account/variables.tf
@@ -19,8 +19,9 @@ variable "vnet_ids" {
   type        = map(string)
 }
 
-variable "runner_public_ip" {
+/* variable "runner_public_ip" {
   type        = string
   description = "Public IP of the GitHub Actions runner"
 }
 
+ */

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,7 +31,7 @@ output "scripts_sas_token" {
   sensitive = true
 }
 
-output "scripts_sas_url" {
+output "scripts_sas_url_main" {
   value       = module.storage_account.scripts_sas_url
   description = "The SAS URL for the script blob, used for deployment"
   sensitive   = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "firewall_ip" {
-  description = "public ip of afw" 
-  value = module.networking.firewall_ip
+  description = "public ip of afw"
+  value       = module.networking.firewall_ip
 }
 
 output "vnet_ids" {
@@ -27,7 +27,7 @@ output "vm_private_ip" {
 # }
 
 output "scripts_sas_token" {
-  value = module.storage_account.scripts_sas_token
+  value     = module.storage_account.scripts_sas_token
   sensitive = true
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,6 +31,11 @@ output "scripts_sas_token" {
   sensitive = true
 }
 
+output "scripts_sas_url" {
+  value       = module.storage_account.scripts_sas_url
+  description = "The SAS URL for the script blob, used for deployment"
+  sensitive   = true
+}
 
 /* output "blob_url" {
   description = "url of SAS token to container"

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,13 +28,13 @@ output "vm_private_ip" {
 
 output "scripts_sas_token" {
   value = module.storage_account.scripts_sas_token
-  sensitive = false
+  sensitive = true
 }
 
 output "scripts_sas_url_main" {
   value       = module.storage_account.scripts_sas_url
   description = "The SAS URL for the script blob, used for deployment"
-  sensitive   = false
+  sensitive   = true
 }
 
 /* output "blob_url" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,13 +28,13 @@ output "vm_private_ip" {
 
 output "scripts_sas_token" {
   value = module.storage_account.scripts_sas_token
-  sensitive = true
+  sensitive = false
 }
 
 output "scripts_sas_url_main" {
   value       = module.storage_account.scripts_sas_url
   description = "The SAS URL for the script blob, used for deployment"
-  sensitive   = true
+  sensitive   = false
 }
 
 /* output "blob_url" {

--- a/variables.tf
+++ b/variables.tf
@@ -91,10 +91,10 @@ variable "terraform_sp_object_id" {
 }
 
 #
-/* variable "runner_public_ip" {
+variable "runner_public_ip" {
   type        = string
   description = "Public IP of the GitHub Actions runner"
-} */
+}
 
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -85,10 +85,10 @@ variable "admin_password" {
   sensitive   = true
 }
 #
-variable "runner_public_ip" {
+/* variable "runner_public_ip" {
   type        = string
   description = "Public IP of the GitHub Actions runner"
-}
+} */
 
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,12 @@ variable "admin_password" {
   type        = string
   sensitive   = true
 }
+
+variable "terraform_sp_object_id" {
+  description = "The Object ID of the Service Principal used by Terraform"
+  type        = string
+}
+
 #
 /* variable "runner_public_ip" {
   type        = string


### PR DESCRIPTION
implemented private endpoints for storage. is "allow" during deployment because gh actions runners are ephemeral and ip may change during deployment. makes so whitelisting becomes difficult. do "allow" during deployment and then "Deny"